### PR TITLE
feat: Update DialogContent width in EditorViewer

### DIFF
--- a/src/components/profile/editor-viewer.tsx
+++ b/src/components/profile/editor-viewer.tsx
@@ -74,10 +74,10 @@ export const EditorViewer = (props: Props) => {
   });
 
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog open={open} onClose={onClose} maxWidth="xl" fullWidth>
       <DialogTitle>{t("Edit File")}</DialogTitle>
 
-      <DialogContent sx={{ width: 520, pb: 1, userSelect: "text" }}>
+      <DialogContent sx={{ width: "95%", pb: 1, userSelect: "text" }}>
         <div style={{ width: "100%", height: "420px" }} ref={editorRef} />
       </DialogContent>
 


### PR DESCRIPTION
目前的脚本编辑窗口是固定宽度，不会随窗口自适应调节，编辑内容较长时不方便查看，修改为自适应宽度

![image](https://github.com/wonfen/clash-verge-rev/assets/96409857/3f73bde2-030d-4094-9566-c557075e25ce)