### PR TITLE
fix: Downgrade runas to fix service install bug

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3700,14 +3700,12 @@ checksum = "e60ef3b82994702bbe4e134d98aadca4b49ed04440148985678d415c68127666"
 
 [[package]]
 name = "runas"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49535b7c73aec5596ae2c44a6d8a7a8f8592e5744564c327fd4846750413d921"
+checksum = "ed87390fefd18965ff20baae5aeb9913bcf82d2b59dc04c0f6d8f17f7be56ff2"
 dependencies = [
- "libc",
- "security-framework-sys",
+ "cc",
  "which",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ wry = { version = "0.24.3" }
 
 
 [target.'cfg(windows)'.dependencies]
-runas = "1.1.0"
+runas = "=1.0.0"
 deelevate = "0.2.0"
 winreg = { version = "0.50", features = ["transactions"] }
 windows-sys = { version = "0.48", features = ["Win32_System_LibraryLoader", "Win32_System_SystemInformation"] }


### PR DESCRIPTION
目前版本在非管理员身份下运行时，安装服务会报错，但实际已经安装成功了。Debug确定是由于runas 1.1.0版本错误返回了exit code导致的，降级到1.0.0可解决。

参考runas的issue  https://github.com/mitsuhiko/rust-runas/issues/13