### PR TITLE
fix: Tray Icon Tooltip is Empty

### DIFF
--- a/src-tauri/src/core/tray.rs
+++ b/src-tauri/src/core/tray.rs
@@ -107,6 +107,20 @@ impl Tray {
     }
 
     pub fn update_part(app_handle: &AppHandle) -> Result<()> {
+        let zh = { Config::verge().latest().language == Some("zh".into()) };
+
+        let version = app_handle.package_info().version.to_string();
+
+        macro_rules! t {
+            ($en: expr, $zh: expr) => {
+                if zh {
+                    $zh
+                } else {
+                    $en
+                }
+            };
+        }
+
         let mode = {
             Config::clash()
                 .latest()
@@ -145,10 +159,9 @@ impl Tray {
 
         #[cfg(not(target_os = "linux"))]
         let _ = tray.set_tooltip(&format!(
-            "Clash Verge {}\nSystem Proxy: {}\nTun Mode: {}",
-            app_handle.package_info().version,
-            system_proxy,
-            tun_mode
+            "Clash Verge {version}\n{}: {system_proxy}\n{}: {tun_mode}",
+            t!("System Proxy", "系统代理"),
+            t!("TUN Mode", "Tun 模式")
         ));
 
         Ok(())

--- a/src-tauri/src/core/tray.rs
+++ b/src-tauri/src/core/tray.rs
@@ -157,11 +157,20 @@ impl Tray {
         let _ = tray.get_item("system_proxy").set_selected(*system_proxy);
         let _ = tray.get_item("tun_mode").set_selected(*tun_mode);
 
+        let switch_map = {
+            let mut map = std::collections::HashMap::new();
+            map.insert(true, "on");
+            map.insert(false, "off");
+            map
+        };
+
         #[cfg(not(target_os = "linux"))]
         let _ = tray.set_tooltip(&format!(
-            "Clash Verge {version}\n{}: {system_proxy}\n{}: {tun_mode}",
+            "Clash Verge {version}\n{}: {}\n{}: {}",
             t!("System Proxy", "系统代理"),
-            t!("TUN Mode", "Tun 模式")
+            switch_map[system_proxy],
+            t!("TUN Mode", "Tun 模式"),
+            switch_map[tun_mode]
         ));
 
         Ok(())

--- a/src-tauri/src/core/tray.rs
+++ b/src-tauri/src/core/tray.rs
@@ -143,6 +143,14 @@ impl Tray {
         let _ = tray.get_item("system_proxy").set_selected(*system_proxy);
         let _ = tray.get_item("tun_mode").set_selected(*tun_mode);
 
+        #[cfg(not(target_os = "linux"))]
+        let _ = tray.set_tooltip(&format!(
+            "Clash Verge {}\nSystem Proxy: {}\nTun Mode: {}",
+            app_handle.package_info().version,
+            system_proxy,
+            tun_mode
+        ));
+
         Ok(())
     }
 


### PR DESCRIPTION
![image](https://github.com/wonfen/clash-verge-rev/assets/59004461/56cbc010-c84b-4787-b788-41b433cc3978)
